### PR TITLE
Added the save method in the EconomyService

### DIFF
--- a/economy/src/main/java/net/impactdev/impactor/api/economy/EconomyService.java
+++ b/economy/src/main/java/net/impactdev/impactor/api/economy/EconomyService.java
@@ -103,7 +103,7 @@ public interface EconomyService extends Service {
      * as virtual, which can be a key indicator for bank accounts or any account not
      * owned by a player.
      *
-     * @param uuid The uuid of the account owner
+     * @param uuid     The uuid of the account owner
      * @param modifier A property which supplies an account builder for further modification
      * @return The stored account, or a new account reflecting the request
      */
@@ -175,5 +175,14 @@ public interface EconomyService extends Service {
      * @return A future useful for indicating task completion
      */
     CompletableFuture<Void> deleteAccount(Currency currency, UUID uuid);
+
+    /**
+     * Saves the given account.
+     *
+     * @param account The account to save
+     */
+    default void save(Account account) {
+        throw new UnsupportedOperationException();
+    }
 
 }


### PR DESCRIPTION
This pull request adds a method for saving accounts in the EconomyService interface. This was done so that ImpactorAccount would not need to fetch ImpactorEconomyService and its storage to save as this breaks other EconomyService implementations that want to use ImpactorAccount.

Related to [Impactor Pull Request 11](https://github.com/NickImpact/Impactor/pull/11).